### PR TITLE
📝  프로젝트 환경설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,17 @@ sourceCompatibility = '11'
 repositories {
 	mavenCentral()
 }
-
+// 우리가 여기 적은 두 라이브러리를 gradle이 땡겨오고, 또 저 두 라이브러리에서 필요한 의존 라이브러리를 계속 땡김
+// 결국 최종적으로 spring core까지 다 땡겨온다.
+// Npm이라고 생각하면 좋을 것 같다.
+// *이 붙어 있는 애들은 이미 위에서 받은 중복이란 뜻
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // web engine
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
-
+// 에전에 Server에 Tomcat을 설치하고 어쩌구... 하지 않는다.
+// 지금은 Tomcat이 내장(embeded)되어 있다. => 예전에 WAS 배포했지만 지금은 아님
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>


### PR DESCRIPTION
## Gradle
### Gradle vs Maven
요즘은 gradle을 많이 사용한다.
쉽게 npm과 비슷하다고 이해했다.
### build.Gradle 기초
  <img width="524" alt="스크린샷 2022-05-06 오전 6 07 13" src="https://user-images.githubusercontent.com/26926966/167025665-0c7c487e-ee67-4854-8c37-ceef33296af9.png">

- 위 사진에서 가장 상위에 있는 두개는 우리가 start.spring.io에서 가져온 두개 thymeleaf, spring-boot-starter-web

### Embedded webserver
예전에는 tomcat을 서버에 설치했었지만, 요즘은 내부에 tomcat을 embedded하고 있다.

## 주요 라이브러리
### spring-boot-starter-web
- spring-boot-starter-tomcat (톰캣)
- spring-webmvc 스프링 웹 MVC
### spring-boot-starter-thymeleaft : 타임리프 템플릿 엔진 (view)
### spring-boot-starter(공통): 스프링부트 + 스프링 코어 + 로깅
- spring-boot
  - spring-core
- spring-boot-starter-logging
  - logback, slf4j


### Logging
시대에 따라 트렌드가 바뀜
요즘 사람들이 많이 쓰는 조합이기에 spring boot 기본으로 설정했다.
거의 표준.
#### slf4j
interface
#### logback
- 어떤 구현채로 출력할지
- 빠르다

### Test
#### JUNIT
4가 많이 유지되다가 최근 5로 넘어가는 추세
#### assertj
- test를 편하게 작성
#### mockito
- mocking
#### spring-test
- 스프링 통합 테스트 지원
- e2e


